### PR TITLE
Minor network call error solution

### DIFF
--- a/R/pagerui.R
+++ b/R/pagerui.R
@@ -6,21 +6,14 @@
 #'
 #' @seealso
 #' \link{updatePageruiInput}
-#' 
+#'
 #' @import shiny
 #' @import htmltools
-#' 
+#'
 #' @export
 pageruiInput = function(inputId, page_current = NULL, pages_total = NULL) {
   # construct the pager-ui framework
   tagList(
-    singleton(
-      tags$head(
-        tags$script(src = 'js/underscore-min.js'),
-        tags$script(src = 'js/input_binding_pager-ui.js')
-      )
-    ),
-
     # root pager-ui node
     div(
       id = inputId,
@@ -75,7 +68,7 @@ pageruiInput = function(inputId, page_current = NULL, pages_total = NULL) {
         span(
           class = 'page-button-group-numbers btn-group'
         ),
-        
+
         # javascript assets
         htmlDependency(
           name = paste(packageName(), 'assets', sep = '-'),
@@ -88,7 +81,7 @@ pageruiInput = function(inputId, page_current = NULL, pages_total = NULL) {
             'js/underscore-min.map'
           )
         )
-        
+
         ##
       )
     )
@@ -104,7 +97,7 @@ pageruiInput = function(inputId, page_current = NULL, pages_total = NULL) {
 #'
 #' @seealso
 #' \link{pageruiInput}
-#' 
+#'
 #' @import shiny
 #' @export
 updatePageruiInput = function(session, inputId, page_current = NULL, pages_total = NULL) {
@@ -117,15 +110,15 @@ updatePageruiInput = function(session, inputId, page_current = NULL, pages_total
 }
 
 #' Runs example application for shinyPagerUI
-#' 
+#'
 #' @importFrom shiny runApp
 #' @export
 runExamplePagerUI = function() {
   app_dir = system.file('example_app', package = packageName())
-  
+
   if (is.na(app_dir) || app_dir == '') {
     stop("Could not find example. Try re-installing package.", call. = FALSE)
   }
-  
+
   runApp(app_dir, display.mode = 'normal')
 }


### PR DESCRIPTION
This commit removes a call to two files that were causing a minor error in the browser due to the files not being in the referenced path in the server.

The error looked like this in the browser when running the demo that comes with the package.
 
![Screenshot from 2020-11-19 13-30-46](https://user-images.githubusercontent.com/16964518/99719377-d5b4d080-2a71-11eb-8b38-0ace22b135e3.png)


The files do not need to be referenced inside the UI-generating function, they are added automatically by Shiny when using htmlDependency (they will be bundled in the "(index)" file when the app runs).

After the change, the errors in the browser disappear.
![Screenshot from 2020-11-19 14-20-44](https://user-images.githubusercontent.com/16964518/99719837-74413180-2a72-11eb-8a12-2be3618f8b47.png)

As you can see, the browser still shows another error related to the "underscore-min.map" file, I'm not sure what can be done to solve it. Any suggestions?
